### PR TITLE
Fix translation hook

### DIFF
--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -1,7 +1,6 @@
-import { useContext, useCallback } from 'react';
+import { useContext } from 'react';
 import { TranslationContext } from '../contexts/TranslationContext';
 import type { TranslationContextType } from '../contexts/TranslationContext';
-import { translateText } from '../services/translationService';
 
 export const useTranslation = (): TranslationContextType => {
   const context = useContext(TranslationContext);
@@ -10,20 +9,9 @@ export const useTranslation = (): TranslationContextType => {
     throw new Error('useTranslation must be used within TranslationProvider');
   }
 
-  const t = useCallback(async (key: string, options?: any) => {
-    const baseTranslation = context.t(key, options);
-    
-    // Only translate if not in default language (English)
-    if (context.currentLanguage !== 'en') {
-      return translateText(baseTranslation, context.currentLanguage);
-    }
-    
-    return baseTranslation;
-  }, [context]);
-
   return {
-    t,
+    t: context.t,
     currentLanguage: context.currentLanguage,
-    changeLanguage: context.changeLanguage
+    changeLanguage: context.changeLanguage,
   };
 };


### PR DESCRIPTION
## Summary
- fix useTranslation hook to return a sync translator function

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find ESLint package)*

------
https://chatgpt.com/codex/tasks/task_e_684951ba88cc832f881ef4abe17698aa